### PR TITLE
Update to  fix alarm logger page 

### DIFF
--- a/minargon/metrics/elasticsearch_api.py
+++ b/minargon/metrics/elasticsearch_api.py
@@ -127,7 +127,7 @@ def prep_alarms(hits, source_cols, component_depth):
 def _get_pv_categs(pv_path, component_depth):
     """Get components of pv path assuming the pv name has a single / in it """
     pv_path = _pv_path_clean(pv_path)
-    components = pv_path.split("state:/SBND/")[1].split("/")
+    components = pv_path.split("state:/SBNDDCS/")[1].split("/")
     pv = "/".join(components[-2:])
     components = components[:-2]
     while len(components) < component_depth:


### PR DESCRIPTION
Epics stuff moved to a new server with sl7 -> alma9 causing the prefix for PV names to change like SBND -> SBNDDCS. Updating this in the hardcoded function for preprocessing elasticsearch alarm data.