### PR TITLE
Update to slow control alarm history page

### DIFF
--- a/minargon/metrics/elasticsearch_api.py
+++ b/minargon/metrics/elasticsearch_api.py
@@ -18,11 +18,11 @@ def make_connection(database):
     return es
 
 
-def get_alarm_data(database):
+def get_alarm_data(database, max_indices):
     """Get raw hits from specified indices in elasticsearch db"""
     es = make_connection(database)
     indices, extra_render_args = _handle_index_gathering(
-        es, ES_INSTANCES[database]["index_gatherer"]
+        es, ES_INSTANCES[database]["index_gatherer"], max_indices
     )
 
     hits = []
@@ -40,14 +40,14 @@ def get_alarm_data(database):
     return hits, extra_render_args
 
 
-def _handle_index_gathering(es, gather_cfg):
+def _handle_index_gathering(es, gather_cfg, max_indices):
     try:
         if gather_cfg["type"] == "single_topic":
             indices = list(es.indices.get(index=topic).keys())
             extra_render_args = {}
         elif gather_cfg["type"] == "monthly":
             indices, extra_render_args = _gather_monthly_indices(
-                es, gather_cfg["topic"], gather_cfg["max_indices"], gather_cfg["strptime_fmt"]
+                es, gather_cfg["topic"], max_indices, gather_cfg["strptime_fmt"]
             )
     except KeyError as e:
         print(

--- a/minargon/templates/sbnd/es_alarms.html
+++ b/minargon/templates/sbnd/es_alarms.html
@@ -7,8 +7,17 @@
   <p> Slow Control Alarms History </p>
 </h1>
 
-<p> Plots can be zoomed, dragged and hovered. Double click to snap axis to fit data. Email alexander.wilkinson.20@ucl.ac.uk with any questions. </p>
+<p> Plots can be zoomed, dragged and hovered. Double click to snap axis to fit data. Talk to slow control experts for any questions. </p>
 
+
+<div id="selectMonths">
+  <label>Select how many past months of alarm data to load:</label>
+  <ul>
+    <label for="monthInput" style="margin-left:16px;">Past months:</label>
+    <input id="monthInput" type="number" min="1" max="120" step="1" value="{{ max_indices }}" style="width: 80px; margin-right:8px;">
+    <button onclick="reloadPage()">Reload (with patience)</button>
+  </ul>
+</div>
 
 <div id="selectDropdowns">
   <label>Show alarms for system(s):</label>
@@ -200,6 +209,11 @@
   function triggerOnChange(element) {
     const ev = new Event("change");
     element.dispatchEvent(ev);
+  }
+
+  function reloadPage() {
+    const months = document.getElementById('monthInput').value;
+    window.location.href = `/Slow_Control_Alarms?months=${months}`;
   }
 
   // end-------------------------------------------------------- 

--- a/minargon/views/sbnd/views.py
+++ b/minargon/views/sbnd/views.py
@@ -892,13 +892,14 @@ def es_alarms():
     source_cols = [ "message_time", "time", "value", "message", "severity", "config" ]
     component_depth = 3
 
-    alarm_hits, extra_render_args = elasticsearch_api.get_alarm_data(database)
+    max_indices = int(request.args.get("months", 1))
+    alarm_hits, extra_render_args = elasticsearch_api.get_alarm_data(database, max_indices)
     alarms, component_hierarchy = elasticsearch_api.prep_alarms(
         alarm_hits, source_cols, component_depth, database
     )
 
     render_args = {
-        "alarms" : alarms, "components" : component_hierarchy
+        "alarms" : alarms, "components" : component_hierarchy, "max_indices" : max_indices
     }
     render_args.update(extra_render_args)
 


### PR DESCRIPTION
Makes the number of past monthly databases to load in for the page configurable (previously was hardcoded at last 4 months because I didnt know what I was doing)

The ELASTICSEARCH_INSTANCES "max_indices" entry is now redundant, Im just going to remove it on the live settings.conf because I dont want to resolve any git conflicts on that file :).